### PR TITLE
Solve UnicodeDecodeError when installing via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 import os
 
 rootdir = os.path.abspath(os.path.dirname(__file__))
-long_description = open(os.path.join(rootdir, 'README.md')).read()
+long_description = open(os.path.join(rootdir, 'README.md'), encoding='utf-8').read()
 
 setuptools.setup(
     name="SmoothNLP",


### PR DESCRIPTION
locale.getpreferedencoding does not return 'utf-8' on windows, so it's best practice to specify 'utf-8' in open(). 
This is a common mistake in setup.py made by many python projects.